### PR TITLE
Upgrade terraform-provider-minio to v1.15.2

### DIFF
--- a/provider/cmd/pulumi-resource-minio/schema.json
+++ b/provider/cmd/pulumi-resource-minio/schema.json
@@ -1024,8 +1024,7 @@
                 },
                 "objectLocking": {
                     "type": "boolean",
-                    "description": "- Whether object locking should be enabled for the bucket.\n",
-                    "willReplaceOnChanges": true
+                    "description": "- Whether object locking should be enabled for the bucket.\n"
                 },
                 "quota": {
                     "type": "integer",
@@ -1057,8 +1056,7 @@
                     },
                     "objectLocking": {
                         "type": "boolean",
-                        "description": "- Whether object locking should be enabled for the bucket.\n",
-                        "willReplaceOnChanges": true
+                        "description": "- Whether object locking should be enabled for the bucket.\n"
                     },
                     "quota": {
                         "type": "integer",

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -11,7 +11,7 @@ replace (
 )
 
 require (
-	github.com/aminueza/terraform-provider-minio v1.15.1
+	github.com/aminueza/terraform-provider-minio v1.15.2
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.46.1
 	github.com/pulumi/pulumi/sdk/v3 v3.66.0
 )

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -356,8 +356,8 @@ github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk5
 github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
 github.com/alexflint/go-filemutex v0.0.0-20171022225611-72bdc8eae2ae/go.mod h1:CgnQgUtFrFz9mxFNtED3jI5tLDjKlOM+oUF/sTk6ps0=
 github.com/alexflint/go-filemutex v1.1.0/go.mod h1:7P4iRhttt/nUvUOrYIhcpMzv2G6CY9UnI16Z+UJqRyk=
-github.com/aminueza/terraform-provider-minio v1.15.1 h1:emT9LLNy4aSxhOoFeUZMGkAGEwBG7DNS1R8GRasFEAc=
-github.com/aminueza/terraform-provider-minio v1.15.1/go.mod h1:B76fGGUJU5HvQSxw21D4/EjsTrNDhTHfpO2JNspigAk=
+github.com/aminueza/terraform-provider-minio v1.15.2 h1:Px8+e5WW/8cjLlqSppOxezmz6u7PNsezA9G+VYvk418=
+github.com/aminueza/terraform-provider-minio v1.15.2/go.mod h1:B76fGGUJU5HvQSxw21D4/EjsTrNDhTHfpO2JNspigAk=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=


### PR DESCRIPTION
This PR was generated via `$ upgrade-provider pulumi/pulumi-minio`.

---

- Upgrading terraform-provider-minio from 1.15.1  to 1.15.2.
Fixes #100 
