### PR TITLE
Specify s3Bucket.quota as a "number" (instead of a "integer")

### DIFF
--- a/provider/cmd/pulumi-resource-minio/schema.json
+++ b/provider/cmd/pulumi-resource-minio/schema.json
@@ -1035,7 +1035,7 @@
                     "type": "boolean"
                 },
                 "quota": {
-                    "type": "integer"
+                    "type": "number"
                 }
             },
             "required": [
@@ -1062,7 +1062,7 @@
                     "type": "boolean"
                 },
                 "quota": {
-                    "type": "integer"
+                    "type": "number"
                 }
             },
             "stateInputs": {
@@ -1092,7 +1092,7 @@
                         "type": "boolean"
                     },
                     "quota": {
-                        "type": "integer"
+                        "type": "number"
                     }
                 },
                 "type": "object"

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -48,16 +48,30 @@ func Provider() tfbridge.ProviderInfo {
 
 	// Create a Pulumi provider mapping
 	prov := tfbridge.ProviderInfo{
-		P:           p,
-		Name:        "minio",
-		Description: "A Pulumi package for creating and managing minio cloud resources.",
-		Keywords:    []string{"pulumi", "minio"},
-		License:     "Apache-2.0",
-		Homepage:    "https://pulumi.io",
-		Repository:  "https://github.com/pulumi/pulumi-minio",
-		GitHubOrg:   "aminueza",
-		Config:      map[string]*tfbridge.SchemaInfo{},
-		Version:     version.Version,
+		P:            p,
+		Name:         "minio",
+		Description:  "A Pulumi package for creating and managing minio cloud resources.",
+		Keywords:     []string{"pulumi", "minio"},
+		License:      "Apache-2.0",
+		Homepage:     "https://pulumi.io",
+		Repository:   "https://github.com/pulumi/pulumi-minio",
+		GitHubOrg:    "aminueza",
+		Config:       map[string]*tfbridge.SchemaInfo{},
+		Version:      version.Version,
+		MetadataInfo: tfbridge.NewProviderMetadata(metadata),
+
+		Resources: map[string]*tfbridge.ResourceInfo{
+			"minio_s3_bucket": {Fields: map[string]*tfbridge.SchemaInfo{
+				// quota should be a u64 since it describes bytes sizes.
+				//
+				// The Pulumi schema doesn't support u64 (or i64), so we
+				// are converting to a float64, which should get us at
+				// least 2^52 bits of precision while minimizing the
+				// breaking change (int -> float) for our users.
+				"quota": {Type: "number"},
+			}},
+		},
+
 		JavaScript: &tfbridge.JavaScriptInfo{
 			Dependencies: map[string]string{
 				"@pulumi/pulumi": "^3.0.0",
@@ -92,7 +106,6 @@ func Provider() tfbridge.ProviderInfo {
 				"Pulumi": "3.*",
 			},
 		},
-		MetadataInfo: tfbridge.NewProviderMetadata(metadata),
 	}
 
 	prov.MustComputeTokens(tokens.SingleModule("minio_", mainMod,

--- a/sdk/dotnet/S3Bucket.cs
+++ b/sdk/dotnet/S3Bucket.cs
@@ -59,7 +59,7 @@ namespace Pulumi.Minio
         public Output<bool?> ObjectLocking { get; private set; } = null!;
 
         [Output("quota")]
-        public Output<int?> Quota { get; private set; } = null!;
+        public Output<double?> Quota { get; private set; } = null!;
 
 
         /// <summary>
@@ -123,7 +123,7 @@ namespace Pulumi.Minio
         public Input<bool>? ObjectLocking { get; set; }
 
         [Input("quota")]
-        public Input<int>? Quota { get; set; }
+        public Input<double>? Quota { get; set; }
 
         public S3BucketArgs()
         {
@@ -155,7 +155,7 @@ namespace Pulumi.Minio
         public Input<bool>? ObjectLocking { get; set; }
 
         [Input("quota")]
-        public Input<int>? Quota { get; set; }
+        public Input<double>? Quota { get; set; }
 
         public S3BucketState()
         {

--- a/sdk/go/minio/s3bucket.go
+++ b/sdk/go/minio/s3bucket.go
@@ -42,14 +42,14 @@ import (
 type S3Bucket struct {
 	pulumi.CustomResourceState
 
-	Acl              pulumi.StringPtrOutput `pulumi:"acl"`
-	Arn              pulumi.StringOutput    `pulumi:"arn"`
-	Bucket           pulumi.StringOutput    `pulumi:"bucket"`
-	BucketDomainName pulumi.StringOutput    `pulumi:"bucketDomainName"`
-	BucketPrefix     pulumi.StringPtrOutput `pulumi:"bucketPrefix"`
-	ForceDestroy     pulumi.BoolPtrOutput   `pulumi:"forceDestroy"`
-	ObjectLocking    pulumi.BoolPtrOutput   `pulumi:"objectLocking"`
-	Quota            pulumi.IntPtrOutput    `pulumi:"quota"`
+	Acl              pulumi.StringPtrOutput  `pulumi:"acl"`
+	Arn              pulumi.StringOutput     `pulumi:"arn"`
+	Bucket           pulumi.StringOutput     `pulumi:"bucket"`
+	BucketDomainName pulumi.StringOutput     `pulumi:"bucketDomainName"`
+	BucketPrefix     pulumi.StringPtrOutput  `pulumi:"bucketPrefix"`
+	ForceDestroy     pulumi.BoolPtrOutput    `pulumi:"forceDestroy"`
+	ObjectLocking    pulumi.BoolPtrOutput    `pulumi:"objectLocking"`
+	Quota            pulumi.Float64PtrOutput `pulumi:"quota"`
 }
 
 // NewS3Bucket registers a new resource with the given unique name, arguments, and options.
@@ -82,14 +82,14 @@ func GetS3Bucket(ctx *pulumi.Context,
 
 // Input properties used for looking up and filtering S3Bucket resources.
 type s3bucketState struct {
-	Acl              *string `pulumi:"acl"`
-	Arn              *string `pulumi:"arn"`
-	Bucket           *string `pulumi:"bucket"`
-	BucketDomainName *string `pulumi:"bucketDomainName"`
-	BucketPrefix     *string `pulumi:"bucketPrefix"`
-	ForceDestroy     *bool   `pulumi:"forceDestroy"`
-	ObjectLocking    *bool   `pulumi:"objectLocking"`
-	Quota            *int    `pulumi:"quota"`
+	Acl              *string  `pulumi:"acl"`
+	Arn              *string  `pulumi:"arn"`
+	Bucket           *string  `pulumi:"bucket"`
+	BucketDomainName *string  `pulumi:"bucketDomainName"`
+	BucketPrefix     *string  `pulumi:"bucketPrefix"`
+	ForceDestroy     *bool    `pulumi:"forceDestroy"`
+	ObjectLocking    *bool    `pulumi:"objectLocking"`
+	Quota            *float64 `pulumi:"quota"`
 }
 
 type S3BucketState struct {
@@ -100,7 +100,7 @@ type S3BucketState struct {
 	BucketPrefix     pulumi.StringPtrInput
 	ForceDestroy     pulumi.BoolPtrInput
 	ObjectLocking    pulumi.BoolPtrInput
-	Quota            pulumi.IntPtrInput
+	Quota            pulumi.Float64PtrInput
 }
 
 func (S3BucketState) ElementType() reflect.Type {
@@ -108,12 +108,12 @@ func (S3BucketState) ElementType() reflect.Type {
 }
 
 type s3bucketArgs struct {
-	Acl           *string `pulumi:"acl"`
-	Bucket        *string `pulumi:"bucket"`
-	BucketPrefix  *string `pulumi:"bucketPrefix"`
-	ForceDestroy  *bool   `pulumi:"forceDestroy"`
-	ObjectLocking *bool   `pulumi:"objectLocking"`
-	Quota         *int    `pulumi:"quota"`
+	Acl           *string  `pulumi:"acl"`
+	Bucket        *string  `pulumi:"bucket"`
+	BucketPrefix  *string  `pulumi:"bucketPrefix"`
+	ForceDestroy  *bool    `pulumi:"forceDestroy"`
+	ObjectLocking *bool    `pulumi:"objectLocking"`
+	Quota         *float64 `pulumi:"quota"`
 }
 
 // The set of arguments for constructing a S3Bucket resource.
@@ -123,7 +123,7 @@ type S3BucketArgs struct {
 	BucketPrefix  pulumi.StringPtrInput
 	ForceDestroy  pulumi.BoolPtrInput
 	ObjectLocking pulumi.BoolPtrInput
-	Quota         pulumi.IntPtrInput
+	Quota         pulumi.Float64PtrInput
 }
 
 func (S3BucketArgs) ElementType() reflect.Type {
@@ -241,8 +241,8 @@ func (o S3BucketOutput) ObjectLocking() pulumi.BoolPtrOutput {
 	return o.ApplyT(func(v *S3Bucket) pulumi.BoolPtrOutput { return v.ObjectLocking }).(pulumi.BoolPtrOutput)
 }
 
-func (o S3BucketOutput) Quota() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v *S3Bucket) pulumi.IntPtrOutput { return v.Quota }).(pulumi.IntPtrOutput)
+func (o S3BucketOutput) Quota() pulumi.Float64PtrOutput {
+	return o.ApplyT(func(v *S3Bucket) pulumi.Float64PtrOutput { return v.Quota }).(pulumi.Float64PtrOutput)
 }
 
 type S3BucketArrayOutput struct{ *pulumi.OutputState }

--- a/sdk/java/src/main/java/com/pulumi/minio/S3Bucket.java
+++ b/sdk/java/src/main/java/com/pulumi/minio/S3Bucket.java
@@ -11,7 +11,7 @@ import com.pulumi.minio.S3BucketArgs;
 import com.pulumi.minio.Utilities;
 import com.pulumi.minio.inputs.S3BucketState;
 import java.lang.Boolean;
-import java.lang.Integer;
+import java.lang.Double;
 import java.lang.String;
 import java.util.Optional;
 import javax.annotation.Nullable;
@@ -100,10 +100,10 @@ public class S3Bucket extends com.pulumi.resources.CustomResource {
     public Output<Optional<Boolean>> objectLocking() {
         return Codegen.optional(this.objectLocking);
     }
-    @Export(name="quota", refs={Integer.class}, tree="[0]")
-    private Output</* @Nullable */ Integer> quota;
+    @Export(name="quota", refs={Double.class}, tree="[0]")
+    private Output</* @Nullable */ Double> quota;
 
-    public Output<Optional<Integer>> quota() {
+    public Output<Optional<Double>> quota() {
         return Codegen.optional(this.quota);
     }
 

--- a/sdk/java/src/main/java/com/pulumi/minio/S3BucketArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/minio/S3BucketArgs.java
@@ -6,7 +6,7 @@ package com.pulumi.minio;
 import com.pulumi.core.Output;
 import com.pulumi.core.annotations.Import;
 import java.lang.Boolean;
-import java.lang.Integer;
+import java.lang.Double;
 import java.lang.String;
 import java.util.Objects;
 import java.util.Optional;
@@ -53,9 +53,9 @@ public final class S3BucketArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     @Import(name="quota")
-    private @Nullable Output<Integer> quota;
+    private @Nullable Output<Double> quota;
 
-    public Optional<Output<Integer>> quota() {
+    public Optional<Output<Double>> quota() {
         return Optional.ofNullable(this.quota);
     }
 
@@ -133,12 +133,12 @@ public final class S3BucketArgs extends com.pulumi.resources.ResourceArgs {
             return objectLocking(Output.of(objectLocking));
         }
 
-        public Builder quota(@Nullable Output<Integer> quota) {
+        public Builder quota(@Nullable Output<Double> quota) {
             $.quota = quota;
             return this;
         }
 
-        public Builder quota(Integer quota) {
+        public Builder quota(Double quota) {
             return quota(Output.of(quota));
         }
 

--- a/sdk/java/src/main/java/com/pulumi/minio/inputs/S3BucketState.java
+++ b/sdk/java/src/main/java/com/pulumi/minio/inputs/S3BucketState.java
@@ -6,7 +6,7 @@ package com.pulumi.minio.inputs;
 import com.pulumi.core.Output;
 import com.pulumi.core.annotations.Import;
 import java.lang.Boolean;
-import java.lang.Integer;
+import java.lang.Double;
 import java.lang.String;
 import java.util.Objects;
 import java.util.Optional;
@@ -67,9 +67,9 @@ public final class S3BucketState extends com.pulumi.resources.ResourceArgs {
     }
 
     @Import(name="quota")
-    private @Nullable Output<Integer> quota;
+    private @Nullable Output<Double> quota;
 
-    public Optional<Output<Integer>> quota() {
+    public Optional<Output<Double>> quota() {
         return Optional.ofNullable(this.quota);
     }
 
@@ -167,12 +167,12 @@ public final class S3BucketState extends com.pulumi.resources.ResourceArgs {
             return objectLocking(Output.of(objectLocking));
         }
 
-        public Builder quota(@Nullable Output<Integer> quota) {
+        public Builder quota(@Nullable Output<Double> quota) {
             $.quota = quota;
             return this;
         }
 
-        public Builder quota(Integer quota) {
+        public Builder quota(Double quota) {
             return quota(Output.of(quota));
         }
 

--- a/sdk/python/pulumi_minio/s3_bucket.py
+++ b/sdk/python/pulumi_minio/s3_bucket.py
@@ -19,7 +19,7 @@ class S3BucketArgs:
                  bucket_prefix: Optional[pulumi.Input[str]] = None,
                  force_destroy: Optional[pulumi.Input[bool]] = None,
                  object_locking: Optional[pulumi.Input[bool]] = None,
-                 quota: Optional[pulumi.Input[int]] = None):
+                 quota: Optional[pulumi.Input[float]] = None):
         """
         The set of arguments for constructing a S3Bucket resource.
         """
@@ -83,11 +83,11 @@ class S3BucketArgs:
 
     @property
     @pulumi.getter
-    def quota(self) -> Optional[pulumi.Input[int]]:
+    def quota(self) -> Optional[pulumi.Input[float]]:
         return pulumi.get(self, "quota")
 
     @quota.setter
-    def quota(self, value: Optional[pulumi.Input[int]]):
+    def quota(self, value: Optional[pulumi.Input[float]]):
         pulumi.set(self, "quota", value)
 
 
@@ -101,7 +101,7 @@ class _S3BucketState:
                  bucket_prefix: Optional[pulumi.Input[str]] = None,
                  force_destroy: Optional[pulumi.Input[bool]] = None,
                  object_locking: Optional[pulumi.Input[bool]] = None,
-                 quota: Optional[pulumi.Input[int]] = None):
+                 quota: Optional[pulumi.Input[float]] = None):
         """
         Input properties used for looking up and filtering S3Bucket resources.
         """
@@ -187,11 +187,11 @@ class _S3BucketState:
 
     @property
     @pulumi.getter
-    def quota(self) -> Optional[pulumi.Input[int]]:
+    def quota(self) -> Optional[pulumi.Input[float]]:
         return pulumi.get(self, "quota")
 
     @quota.setter
-    def quota(self, value: Optional[pulumi.Input[int]]):
+    def quota(self, value: Optional[pulumi.Input[float]]):
         pulumi.set(self, "quota", value)
 
 
@@ -205,7 +205,7 @@ class S3Bucket(pulumi.CustomResource):
                  bucket_prefix: Optional[pulumi.Input[str]] = None,
                  force_destroy: Optional[pulumi.Input[bool]] = None,
                  object_locking: Optional[pulumi.Input[bool]] = None,
-                 quota: Optional[pulumi.Input[int]] = None,
+                 quota: Optional[pulumi.Input[float]] = None,
                  __props__=None):
         """
         ## Example Usage
@@ -264,7 +264,7 @@ class S3Bucket(pulumi.CustomResource):
                  bucket_prefix: Optional[pulumi.Input[str]] = None,
                  force_destroy: Optional[pulumi.Input[bool]] = None,
                  object_locking: Optional[pulumi.Input[bool]] = None,
-                 quota: Optional[pulumi.Input[int]] = None,
+                 quota: Optional[pulumi.Input[float]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -299,7 +299,7 @@ class S3Bucket(pulumi.CustomResource):
             bucket_prefix: Optional[pulumi.Input[str]] = None,
             force_destroy: Optional[pulumi.Input[bool]] = None,
             object_locking: Optional[pulumi.Input[bool]] = None,
-            quota: Optional[pulumi.Input[int]] = None) -> 'S3Bucket':
+            quota: Optional[pulumi.Input[float]] = None) -> 'S3Bucket':
         """
         Get an existing S3Bucket resource's state with the given name, id, and optional extra
         properties used to qualify the lookup.
@@ -359,6 +359,6 @@ class S3Bucket(pulumi.CustomResource):
 
     @property
     @pulumi.getter
-    def quota(self) -> pulumi.Output[Optional[int]]:
+    def quota(self) -> pulumi.Output[Optional[float]]:
         return pulumi.get(self, "quota")
 


### PR DESCRIPTION
`quota` should be a u64 since it describes bytes sizes.

The Pulumi schema doesn't support u64 (or i64), so we are converting to a float64, which should get us at least 2^52 bits of precision while minimizing the breaking change (int -> float) for our users.

Fixes https://github.com/pulumi/pulumi-minio/issues/449