### PR TITLE
Cleanup deprecated goreleaser flag

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -6,7 +6,6 @@ env:
   MINIO_ACCESS_KEY: minio
   MINIO_SECRET_KEY: minio123
   MINIO_ENABLE_HTTPS: false
-skipWindowsArmBuild: true
 makeTemplate: bridged
 plugins:
   - name: terraform


### PR DESCRIPTION
Remove the flag `skipWindowsArmBuild` from `.ci-mgmt.yml` because support for this was removed a while ago, with the last bits removed in https://github.com/pulumi/ci-mgmt/pull/1074

Change applied based on this section which was removed from https://github.com/pulumi/ci-mgmt/blob/master/provider-ci/internal/pkg/templates/bridged-provider.config.yaml:

```
# Go releaser: add ignore for arm64 windows.
# Only used for minio: https://github.com/search?q=org%3Apulumi+path%3A.ci-mgmt.yaml+%22skipWindowsArmBuild%3A%22&type=code
#skipWindowsArmBuild: false
```